### PR TITLE
Avoid build warnings 'warning: value computed is not used [-Wunused-value]'

### DIFF
--- a/wlanpmk2hcx.c
+++ b/wlanpmk2hcx.c
@@ -35,9 +35,9 @@ bio = BIO_push(b64, bio);
 
 BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
 BIO_write(bio, buffer, length);
-BIO_flush(bio);
+(void) BIO_flush(bio);
 BIO_get_mem_ptr(bio, &bufferPtr);
-BIO_set_close(bio, BIO_NOCLOSE);
+(void) BIO_set_close(bio, BIO_NOCLOSE);
 BIO_free_all(bio);
 *b64text=(*bufferPtr).data;
 return;


### PR DESCRIPTION
After this, my builds are 100% free of warnings