### PR TITLE
hcxhashcattool.c: We need to source pthread.h…

### DIFF
--- a/hcxhashcattool.c
+++ b/hcxhashcattool.c
@@ -16,6 +16,7 @@
 #else
 #include <stdio_ext.h>
 #endif
+#include <pthread.h>
 #include <openssl/evp.h>
 
 #include "include/version.h"


### PR DESCRIPTION
…since we're using its exports.
```
hcxhashcattool.c: In function 'calculatepmk':
hcxhashcattool.c:150:9: warning: implicit declaration of function 'pthread_create'; did you mean 'pthread_sigmask'? [-Wimplicit-function-declaration]
   ret = pthread_create( &thread[c], NULL, &calculatethread, &args[c]);
         ^~~~~~~~~~~~~~
         pthread_sigmask
hcxhashcattool.c:160:3: warning: implicit declaration of function 'pthread_join'; did you mean 'pthread_kill'? [-Wimplicit-function-declaration]
   pthread_join(thread[c], NULL);
   ^~~~~~~~~~~~
   pthread_kill
```