### PR TITLE
compile error with musl libc

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ by using common wordlists. Convert the cap to hccapx and check if wlan-key
 or plainmasterkey was transmitted unencrypted.
 
 
-Brief description
+Brief description  
 --------------
 
 Multiple stand-alone binaries - designed to run on Raspberry Pi's.


### PR DESCRIPTION
```
In file included from /usr/include/linux/wireless.h:74:0,
                 from hcxdumptool.c:25:
/usr/include/linux/if.h:142:8: error: redefinition of 'struct ifmap'
 struct ifmap {
        ^~~~~
```


since you disabled issue tracker for this repo, i needed to create a fake PR.

you can reproduce the issue with alpine linux or sabotage linux.