### PR TITLE
Align dots after typo correction

### DIFF
--- a/wlanhcxinfo.c
+++ b/wlanhcxinfo.c
@@ -423,8 +423,8 @@ if(outmode == 0)
 	{
 	fprintf(stdout, "total hashes read from file.......: %ld\n"
 			"\x1B[32mhandshakes from clients...........: %ld\x1B[0m\n"
-			"little endian router detected....: %ld\n"
-			"big endian router detected.......: %ld\n"
+			"little endian router detected.....: %ld\n"
+			"big endian router detected........: %ld\n"
 			"zeroed ESSID......................: %ld\n"
 			"802.1x Version 2001...............: %ld\n"
 			"802.1x Version 2004...............: %ld\n"


### PR DESCRIPTION
Sorry, just realized I forgot to add an additional dot in order to align the output after a letter was removed. :)