### PR TITLE
make: rework build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.deps
 pioff
 whoismac
 wlancap2hcx

--- a/Makefile
+++ b/Makefile
@@ -17,110 +17,75 @@ CFLAGS += -L/usr/local/opt/openssl/lib -I/usr/local/opt/openssl/include
 endif
 
 
-all: build
+TOOLS=
+TOOLS+=hcxpcaptool
+hcxpcaptool_libs=-lz -lcrypto
+TOOLS+=hcxhashcattool
+hcxhashcattool_libs=-lcrypto -lpthread
+TOOLS+=wlanhc2hcx
+TOOLS+=wlanwkp2hcx
+TOOLS+=wlanhcxinfo
+TOOLS+=wlanhcx2cap
+wlanhcx2cap_libs=-lpcap
+TOOLS+=wlanhcx2essid
+TOOLS+=wlanhcx2ssid
+TOOLS+=wlanhcxmnc
+TOOLS+=wlanhashhcx
+TOOLS+=wlanhcxcat
+wlanhcxcat_libs=-lcrypto
+TOOLS+=wlanpmk2hcx
+wlanpmk2hcx_libs=-lcrypto
+TOOLS+=wlanjohn2hcx
+TOOLS+=wlancow2hcxpmk
+TOOLS+=whoismac
+whoismac_libs=-lcurl
+TOOLS+=wlanhcx2john
+TOOLS+=wlanhcx2psk
+wlanhcx2psk_libs=-lcrypto
+TOOLS+=wlancap2wpasec
+wlancap2wpasec_libs=-lcurl
 
-build:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o hcxpcaptool hcxpcaptool.c -lz -lcrypto $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o hcxhashcattool hcxhashcattool.c -lcrypto -lpthread  $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanhc2hcx wlanhc2hcx.c $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanwkp2hcx wlanwkp2hcx.c $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanhcxinfo wlanhcxinfo.c $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanhcx2cap wlanhcx2cap.c -lpcap $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanhcx2essid wlanhcx2essid.c $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanhcx2ssid wlanhcx2ssid.c $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanhcxmnc wlanhcxmnc.c $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanhashhcx wlanhashhcx.c $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanhcxcat wlanhcxcat.c -lcrypto $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanpmk2hcx wlanpmk2hcx.c -lcrypto $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanjohn2hcx wlanjohn2hcx.c $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlancow2hcxpmk wlancow2hcxpmk.c $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o whoismac whoismac.c -lcurl $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanhcx2john wlanhcx2john.c $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlanhcx2psk wlanhcx2psk.c -lcrypto $(LDFLAGS)
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o wlancap2wpasec wlancap2wpasec.c -lcurl $(LDFLAGS)
+.PHONY: build
+build: $(TOOLS)
 
+.deps:
+	mkdir -p .deps
 
-install: build
-	install $(INSTFLAGS) hcxpcaptool $(INSTALLDIR)/hcxpcaptool
-	install $(INSTFLAGS) hcxhashcattool $(INSTALLDIR)/hcxhashcattool
-	install $(INSTFLAGS) wlanhc2hcx $(INSTALLDIR)/wlanhc2hcx
-	install $(INSTFLAGS) wlanwkp2hcx $(INSTALLDIR)/wlanwkp2hcx
-	install $(INSTFLAGS) wlanhcxinfo $(INSTALLDIR)/wlanhcxinfo
-	install $(INSTFLAGS) wlanhcx2cap $(INSTALLDIR)/wlanhcx2cap
-	install $(INSTFLAGS) wlanhcx2essid $(INSTALLDIR)/wlanhcx2essid
-	install $(INSTFLAGS) wlanhcx2ssid $(INSTALLDIR)/wlanhcx2ssid
-	install $(INSTFLAGS) wlanhcxmnc $(INSTALLDIR)/wlanhcxmnc
-	install $(INSTFLAGS) wlanhashhcx $(INSTALLDIR)/wlanhashhcx
-	install $(INSTFLAGS) wlanhcxcat $(INSTALLDIR)/wlanhcxcat
-	install $(INSTFLAGS) wlanpmk2hcx $(INSTALLDIR)/wlanpmk2hcx
-	install $(INSTFLAGS) wlanjohn2hcx $(INSTALLDIR)/wlanjohn2hcx
-	install $(INSTFLAGS) wlancow2hcxpmk $(INSTALLDIR)/wlancow2hcxpmk
-	install $(INSTFLAGS) whoismac $(INSTALLDIR)/whoismac
-	install $(INSTFLAGS) wlanhcx2john $(INSTALLDIR)/wlanhcx2john
-	install $(INSTFLAGS) wlanhcx2psk $(INSTALLDIR)/wlanhcx2psk
-	install $(INSTFLAGS) wlancap2wpasec $(INSTALLDIR)/wlancap2wpasec
+# $1: tool name
+define tool-build
+$(1)_src ?= $(1).c
+$(1)_libs ?=
 
-	rm -f hcxpcaptool
-	rm -f hcxhashcattool
-	rm -f wlanhc2hcx
-	rm -f wlanwkp2hcx
-	rm -f wlanhcxinfo
-	rm -f wlanhcx2cap
-	rm -f wlanhcx2essid
-	rm -f wlanhcx2ssid
-	rm -f wlanhcx2john
-	rm -f wlanhcxmnc
-	rm -f wlanhashhcx
-	rm -f wlanhcxcat
-	rm -f wlanpmk2hcx
-	rm -f wlanjohn2hcx
-	rm -f wlancow2hcxpmk
-	rm -f whoismac
-	rm -f wlanhcx2john
-	rm -f wlanhcx2psk
-	rm -f wlancap2wpasec
-	rm -f *.o *~
+$(1): $$($(1)_src) | .deps
+	$$(CC) $$(CFLAGS) $$(CPPFLAGS) -MMD -MF .deps/$$@.d -o $$@ $$($(1)_src) $$($(1)_libs) $$(LDFLAGS)
 
+.deps/$(1).d: $(1)
 
-clean:
-	rm -f hcxpcaptool
-	rm -f hcxhashcattool
-	rm -f wlanhc2hcx
-	rm -f wlanwkp2hcx
-	rm -f wlanhcxinfo
-	rm -f wlanhcx2cap
-	rm -f wlanhcx2essid
-	rm -f wlanhcx2ssid
-	rm -f wlanhcx2john
-	rm -f wlanhcxmnc
-	rm -f wlanhashhcx
-	rm -f wlanhcxcat
-	rm -f wlanpmk2hcx
-	rm -f wlanjohn2hcx
-	rm -f wlancow2hcxpmk
-	rm -f whoismac
-	rm -f wlanhcx2john
-	rm -f wlanhcx2psk
-	rm -f wlancap2wpasec
-	rm -f *.o *~
+.PHONY: $(1).install
+$(1).install: $(1)
+	install $$(INSTFLAGS) $(1) $$(INSTALLDIR)/$(1)
 
+.PHONY: $(1).clean
+$(1).clean:
+	rm -f .deps/$(1).d
+	rm -f $(1)
 
-uninstall:
-	rm -f $(INSTALLDIR)/hcxpcaptool
-	rm -f $(INSTALLDIR)/hcxhashcattool
-	rm -f $(INSTALLDIR)/wlanhc2hcx
-	rm -f $(INSTALLDIR)/wlanwkp2hcx
-	rm -f $(INSTALLDIR)/wlanhcx2cap
-	rm -f $(INSTALLDIR)/wlanhcx2essid
-	rm -f $(INSTALLDIR)/wlanhcx2ssid
-	rm -f $(INSTALLDIR)/wlanhcxinfo
-	rm -f $(INSTALLDIR)/wlanhcxmnc
-	rm -f $(INSTALLDIR)/wlanhashhcx
-	rm -f $(INSTALLDIR)/wlanhcxcat
-	rm -f $(INSTALLDIR)/wlanpmk2hcx
-	rm -f $(INSTALLDIR)/wlanjohn2hcx
-	rm -f $(INSTALLDIR)/wlancow2hcxpmk
-	rm -f $(INSTALLDIR)/whoismac
-	rm -f $(INSTALLDIR)/wlanhcx2john
-	rm -f $(INSTALLDIR)/wlanhcx2psk
-	rm -f $(INSTALLDIR)/wlancap2wpasec
+.PHONY: $(1).uninstall
+$(1).uninstall:
+	rm -rf $$(INSTALLDIR)/$(1)
+
+endef
+
+$(foreach tool,$(TOOLS),$(eval $(call tool-build,$(tool))))
+
+.PHONY: install
+install: $(patsubst %,%.install,$(TOOLS))
+
+.PHONY: clean
+clean: $(patsubst %,%.clean,$(TOOLS))
+	rm -rf .deps
+
+.PHONY: uninstall
+uninstall: $(patsubst %,%.uninstall,$(TOOLS))
+
+-include .deps/*.d


### PR DESCRIPTION
With an eye primarily at things that packaging of this easier in source
based distros, this change enables the following:

 - avoid rebuilding when just trying to `install`
 - avoid rebuilding unchanged tools
 - allow adding new tools in 1 location instead of ~3
 - allow parallel make to function

It does this by using some gnu make tools (foreach, call, eval,
patsubst).

Of primary interest for my current needs are the 4th & 1st items.