### PR TITLE
Add support for OpenBSD

### DIFF
--- a/common.h
+++ b/common.h
@@ -6,7 +6,7 @@
 #include <endian.h>
 #endif
 
-#ifdef __APPLE__
+#if defined (__APPLE__) || defined(__OpenBSD__)
 #define __BYTE_ORDER BYTE_ORDER
 #define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN

--- a/hcxhashcattool.c
+++ b/hcxhashcattool.c
@@ -10,7 +10,7 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined (__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/hcxpcaptool.c
+++ b/hcxpcaptool.c
@@ -14,9 +14,10 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <openssl/sha.h>
-#ifdef __APPLE__
+#if defined (__APPLE__) || defined(__OpenBSD__)
 #define PATH_MAX 255
 #include <libgen.h>
+#include <sys/socket.h>
 #else
 #include <stdio_ext.h>
 #endif

--- a/hcxpsktool.c
+++ b/hcxpsktool.c
@@ -12,7 +12,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <openssl/md5.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlancap2wpasec.c
+++ b/wlancap2wpasec.c
@@ -8,7 +8,7 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
-#ifdef __APPLE__
+#if defined (__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlancow2hcxpmk.c
+++ b/wlancow2hcxpmk.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanhashhcx.c
+++ b/wlanhashhcx.c
@@ -9,7 +9,7 @@
 #include <limits.h>
 #include <time.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanhc2hcx.c
+++ b/wlanhc2hcx.c
@@ -9,7 +9,7 @@
 #include <limits.h>
 #include <time.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanhcx2cap.c
+++ b/wlanhcx2cap.c
@@ -11,7 +11,7 @@
 /* this will be the last pcap dependency we have to remove */
 #include <pcap.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanhcx2essid.c
+++ b/wlanhcx2essid.c
@@ -9,7 +9,7 @@
 #include <limits.h>
 #include <time.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanhcx2john.c
+++ b/wlanhcx2john.c
@@ -9,7 +9,7 @@
 #include <limits.h>
 #include <time.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanhcx2psk.c
+++ b/wlanhcx2psk.c
@@ -10,7 +10,7 @@
 #include <time.h>
 #include <ctype.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanhcx2ssid.c
+++ b/wlanhcx2ssid.c
@@ -11,7 +11,7 @@
 #include <pwd.h>
 #include <sys/stat.h>
 #include <arpa/inet.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #include <sys/types.h> /* This in turn sources machine/endian.h */
 #else

--- a/wlanhcxcat.c
+++ b/wlanhcxcat.c
@@ -11,7 +11,7 @@
 #include <ctype.h>
 #include <sys/time.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanhcxinfo.c
+++ b/wlanhcxinfo.c
@@ -9,7 +9,7 @@
 #include <limits.h>
 #include <time.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanhcxmnc.c
+++ b/wlanhcxmnc.c
@@ -9,7 +9,7 @@
 #include <limits.h>
 #include <time.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanjohn2hcx.c
+++ b/wlanjohn2hcx.c
@@ -9,7 +9,7 @@
 #include <limits.h>
 #include <time.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanpmk2hcx.c
+++ b/wlanpmk2hcx.c
@@ -11,7 +11,7 @@
 #include <time.h>
 #include <signal.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>

--- a/wlanwkp2hcx.c
+++ b/wlanwkp2hcx.c
@@ -9,7 +9,7 @@
 #include <limits.h>
 #include <time.h>
 #include <sys/stat.h>
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__OpenBSD__)
 #include <libgen.h>
 #else
 #include <stdio_ext.h>


### PR DESCRIPTION
Changes are mostly mechanical, whereever 
#ifdef __APPLE__ 
change to:
#if defined(__APPLE__) || defined (__OpenBSD__)

afterward it builds and seems to do fine.
