### PR TITLE
Fix whoismac -m <full mac address>

### DIFF
--- a/whoismac.c
+++ b/whoismac.c
@@ -411,13 +411,13 @@ while ((auswahl = getopt(argc, argv, "m:v:p:P:dh")) != -1)
 		case 'm':
 		if(strlen(optarg) == 6)
 			{
-			oui = strtoul(optarg, NULL, 16);
+			oui = strtoull(optarg, NULL, 16);
 			mode = 'm';
 			}
 
 		else if(strlen(optarg) == 12)
 			{
-			oui = (strtoul(optarg, NULL, 16) >> 24);
+			oui = (strtoull(optarg, NULL, 16) >> 24);
 			mode = 'm';
 			}
 		else


### PR DESCRIPTION
Looking up the mac -m <OUI> worked quite well, but when giving the
full mac address it failed due to wrong string to integer conversion

Since oui is unsigned long long, apply the same to the conversion
when only the oui is given to the -m parameter

f