### PR TITLE
let things build with gcc < 4.3

### DIFF
--- a/common.c
+++ b/common.c
@@ -34,7 +34,8 @@ return (n & 0xff00) >> 8 | (n & 0x00ff) << 8;
 /*===========================================================================*/
 uint32_t byte_swap_32(uint32_t n)
 {
-#if defined (__clang__) || defined (__GNUC__)
+#if defined (__clang__) || (defined (__GNUC__) && \
+	(__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ > 2))
 return __builtin_bswap32 (n);
 #else
 return(n & 0xff000000) >> 24 | (n & 0x00ff0000) >> 8
@@ -44,7 +45,8 @@ return(n & 0xff000000) >> 24 | (n & 0x00ff0000) >> 8
 /*===========================================================================*/
 uint64_t byte_swap_64(uint64_t n)
 {
-#if defined (__clang__) || defined (__GNUC__)
+#if defined (__clang__) || (defined (__GNUC__) && \
+	(__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ > 2))
 return __builtin_bswap64 (n);
 #else
 return (n & 0xff00000000000000ULL) >> 56

--- a/include/byteops.c
+++ b/include/byteops.c
@@ -36,7 +36,8 @@ return (n & 0xff00) >> 8 | (n & 0x00ff) << 8;
 /*===========================================================================*/
 uint32_t byte_swap_32(uint32_t n)
 {
-#if defined (__clang__) || defined (__GNUC__)
+#if defined (__clang__) || (defined (__GNUC__) && \
+	(__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ > 2))
 return __builtin_bswap32 (n);
 #else
 return(n & 0xff000000) >> 24 | (n & 0x00ff0000) >> 8
@@ -46,7 +47,8 @@ return(n & 0xff000000) >> 24 | (n & 0x00ff0000) >> 8
 /*===========================================================================*/
 uint64_t byte_swap_64(uint64_t n)
 {
-#if defined (__clang__) || defined (__GNUC__)
+#if defined (__clang__) || (defined (__GNUC__) && \
+	(__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ > 2))
 return __builtin_bswap64 (n);
 #else
 return (n & 0xff00000000000000ULL) >> 56


### PR DESCRIPTION
Some of OpenBSD platforms have old system compiler GCC 4.2.1. Looking at the GCC docs, 
the first appearance of the __builtin_bswap32 and __builtin_bswap64 is with GCC 4.3.0, see:
https://gcc.gnu.org/onlinedocs/gcc-4.3.0/gcc/Other-Builtins.html#Other-Builtins
and
https://gcc.gnu.org/onlinedocs/gcc-4.2.4/gcc/Other-Builtins.html#Other-Builtins

This tested and builds with clang now on amd64 and i386, as well as gcc on mips64el.