### PR TITLE
Prevent SIGBUS on mips64el running

### DIFF
--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -220,7 +220,7 @@ typedef struct msnetmon_header msntm_t;
 struct fcs_frame
 {
  uint32_t	fcs;
-};
+} __attribute__((packed));
 typedef struct fcs_frame fcs_t;
 #define	FCS_SIZE (sizeof(fcs_t))
 /*===========================================================================*/


### PR DESCRIPTION
hcxpcaptool -o /path/to/hccapxfile /path/to/infile

While looking into the endianess problem, I ran into 
this one:

In hcxpcaptool.c fcs->fcs is accessed and compared
against crc, and there the SIGBUS happens.

I added the __attribute__((packed)) to the fcs_frame
struct, since every other struct has it there as well, however, 
reading through the gcc docs, attribute packed seems
dangerous, as it may lead to unaligned reads, therefore
I first thougth that an attribute aligned(X) would 
be more appropriate.
I'm not exactly sure what I'm doing here, so take this
with some grain of salt ;)
