### PR TITLE
Fix endianess detection for OpenBSD platforms with compilers

### DIFF
--- a/hcxpcaptool.c
+++ b/hcxpcaptool.c
@@ -37,8 +37,17 @@
 #include "include/hashcatops.c"
 #include "include/johnops.c"
 
+#ifdef __BYTE_ORDER__
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define BIG_ENDIAN_HOST
+#endif
+#else
+#ifdef __OpenBSD__
+# include <endian.h>
+# if BYTE_ORDER == BIG_ENDIAN
+#   define BIG_ENDIAN_HOST
+# endif
+#endif
 #endif
 
 #define MAX_TV_DIFF 600000000llu

--- a/include/hcxpsktool.h
+++ b/include/hcxpsktool.h
@@ -10,8 +10,17 @@
 #define HCXD_HELP			'h'
 #define HCXD_VERSION			'v'
 
+#ifdef __BYTE_ORDER__
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #define BIG_ENDIAN_HOST
+#endif
+#else
+#ifdef __OpenBSD__
+# include <endian.h>
+# if BYTE_ORDER == BIG_ENDIAN
+#   define BIG_ENDIAN_HOST
+# endif
+#endif
 #endif
 
 /*===========================================================================*/

--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -103,6 +103,20 @@
 #define WPA_KEY_INFO_ERROR WBIT(10)
 #define WPA_KEY_INFO_REQUEST WBIT(11)
 #define WPA_KEY_INFO_ENCR_KEY_DATA WBIT(12) /* IEEE 802.11i/RSN only */
+
+#ifdef __BYTE_ORDER__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define BIG_ENDIAN_HOST 1
+#endif
+#else
+#ifdef __OpenBSD__
+# include <endian.h>
+# if BYTE_ORDER == BIG_ENDIAN
+#   define BIG_ENDIAN_HOST 1
+# endif
+#endif
+#endif
+
 /*===========================================================================*/
 struct radiotap_header
 {
@@ -249,7 +263,7 @@ typedef struct qos_frame qos_t;
  */
 struct mac_frame
 {
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#if BIG_ENDIAN_HOST
  unsigned	subtype : 4;
  unsigned	type : 	2;
  unsigned	version : 2;


### PR DESCRIPTION
that don't have __BYTE_ORDER__ defined, i.e. gcc 4.2.

i.e. problem shows up on mips64el with gcc 4.2:
echo "" | cpp -dD | grep ORDER
whereas on amd64 with clang:
 echo "" | cpp -dD | grep ORDER
#define __ORDER_LITTLE_ENDIAN__ 1234
#define __ORDER_BIG_ENDIAN__ 4321
#define __ORDER_PDP_ENDIAN__ 3412
#define __BYTE_ORDER__ __ORDER_LITTLE_ENDIAN__

Problem manifests in the preprocessor with old gcc 4.2.1:
cat hurz.c:
#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
        printf("big");
#else
        printf("little");
#endif

gcc -E hurz.c
...
printf("big");

So for OpenBSD systems, in case __BYTE_ORDER__ is not defined
include <endian.h> and go from there.

since that quite big #ifdef block is now in three places, maybe it would 
make more sense to have it in a single place. Also, I think the endian.h
file is quite common, so, maybe it's worth removing the #ifdef __OpenBSD__
At least you'd easier get problem reports from people having problems to
build, rather than odd endianess problem reports ;)