### PR TITLE
PKCS5_PBKDF2_HMAC to PKCS5_PBKDF2_HMAC_SHA1

### DIFF
--- a/hcxhashcattool.c
+++ b/hcxhashcattool.c
@@ -130,7 +130,7 @@ for(c = 0; c < pmkcountthread; c++)
 	{
 	if(memcmp(&emptypmk, zeiger->pmk, 32) == 0)
 		{
-		if(PKCS5_PBKDF2_HMAC((const char*)zeiger->psk, zeiger->psklen, (unsigned char*)zeiger->essid, zeiger->essidlen, 4096, EVP_sha1(), 32, zeiger->pmk) == 0)
+		if(PKCS5_PBKDF2_HMAC_SHA1((const char*)zeiger->psk, zeiger->psklen, (unsigned char*)zeiger->essid, zeiger->essidlen, 4096, 32, zeiger->pmk) == 0)
 			{
 			printf("failed to calculate PMK\n");
 			exit(EXIT_FAILURE);
@@ -190,7 +190,7 @@ if(ct > 0)
 		{
 		if(memcmp(&emptypmk, zeiger->pmk, 32) == 0)
 			{
-			if(PKCS5_PBKDF2_HMAC((const char*)zeiger->psk, zeiger->psklen, (unsigned char*)zeiger->essid, zeiger->essidlen, 4096, EVP_sha1(), 32, zeiger->pmk) == 0)
+			if(PKCS5_PBKDF2_HMAC_SHA1((const char*)zeiger->psk, zeiger->psklen, (unsigned char*)zeiger->essid, zeiger->essidlen, 4096, 32, zeiger->pmk) == 0)
 				{
 				printf("failed to calculate PMK\n");
 				exit(EXIT_FAILURE);

--- a/wlanhcxcat.c
+++ b/wlanhcxcat.c
@@ -263,7 +263,7 @@ while(c < hcxrecords)
 		zeigerhcx2 = hcxdata +c -1;
 		if(memcmp(zeigerhcx->essid, zeigerhcx2->essid, 32) != 0)
 			{
-			if(PKCS5_PBKDF2_HMAC(passwordname, passwordlen, zeigerhcx->essid, zeigerhcx->essid_len, 4096, EVP_sha1(), 32, pmkin) == 0)
+			if(PKCS5_PBKDF2_HMAC_SHA1(passwordname, passwordlen, zeigerhcx->essid, zeigerhcx->essid_len, 4096, 32, pmkin) == 0)
 				{
 				fprintf(stderr, "could not generate plainmasterkey\n");
 				return;
@@ -273,7 +273,7 @@ while(c < hcxrecords)
 		}
 	else if(c == 0)
 		{
-		if(PKCS5_PBKDF2_HMAC(passwordname, passwordlen, zeigerhcx->essid, zeigerhcx->essid_len, 4096, EVP_sha1(), 32, pmkin) == 0)
+		if(PKCS5_PBKDF2_HMAC_SHA1(passwordname, passwordlen, zeigerhcx->essid, zeigerhcx->essid_len, 4096, 32, pmkin) == 0)
 			{
 			fprintf(stderr, "could not generate plainmasterkey\n");
 			return;
@@ -362,7 +362,7 @@ char outstr[1024];
 
 memcpy(&essid, essidname, essidlen);
 
-if(PKCS5_PBKDF2_HMAC(passwordname, passwordlen, essid, essidlen, 4096, EVP_sha1(), 32, pmkin) == 0)
+if(PKCS5_PBKDF2_HMAC_SHA1(passwordname, passwordlen, essid, essidlen, 4096, 32, pmkin) == 0)
 	{
 	fprintf(stderr, "could not generate plainmasterkey\n");
 	return;


### PR DESCRIPTION
less verbose.