### PR TITLE
Remove inline

### DIFF
--- a/hcxessidtool.c
+++ b/hcxessidtool.c
@@ -752,7 +752,7 @@ printf("%d hashes written to %s\n", written, basename(pmkid12outname));
 return;
 }
 /*===========================================================================*/
-static inline size_t chop(char *buffer, size_t len)
+static size_t chop(char *buffer, size_t len)
 {
 static char *ptr;
 
@@ -774,7 +774,7 @@ while(len)
 return len;
 }
 /*---------------------------------------------------------------------------*/
-static inline int fgetline(FILE *inputstream, size_t size, char *buffer)
+static int fgetline(FILE *inputstream, size_t size, char *buffer)
 {
 static size_t len;
 static char *buffptr;
@@ -1002,14 +1002,14 @@ return true;
 
 /*===========================================================================*/
 __attribute__ ((noreturn))
-static inline void version(char *eigenname)
+static void version(char *eigenname)
 {
 printf("%s %s (C) %s ZeroBeat\n", eigenname, VERSION, VERSION_JAHR);
 exit(EXIT_SUCCESS);
 }
 /*---------------------------------------------------------------------------*/
 __attribute__ ((noreturn))
-static inline void usage(char *eigenname)
+static void usage(char *eigenname)
 {
 printf("%s %s (C) %s ZeroBeat\n"
 	"usage:\n"
@@ -1049,7 +1049,7 @@ exit(EXIT_SUCCESS);
 }
 /*---------------------------------------------------------------------------*/
 __attribute__ ((noreturn))
-static inline void usageerror(char *eigenname)
+static void usageerror(char *eigenname)
 {
 printf("%s %s (C) %s by ZeroBeat\n"
 	"usage: %s -h for help\n", eigenname, VERSION, VERSION_JAHR, eigenname);

--- a/hcxhash2cap.c
+++ b/hcxhash2cap.c
@@ -516,7 +516,7 @@ if(write(fd_cap, packetout, PCAPREC_SIZE +MAC_SIZE_NORM +CAPABILITIESAP_SIZE +2 
 return;
 }
 /*===========================================================================*/
-static inline size_t chop(char *buffer, size_t len)
+static size_t chop(char *buffer, size_t len)
 {
 static char *ptr;
 
@@ -538,7 +538,7 @@ while(len)
 return len;
 }
 /*---------------------------------------------------------------------------*/
-static inline int fgetline(FILE *inputstream, size_t size, char *buffer)
+static int fgetline(FILE *inputstream, size_t size, char *buffer)
 {
 static size_t len;
 static char *buffptr;
@@ -553,7 +553,7 @@ len = chop(buffptr, len);
 return len;
 }
 /*===========================================================================*/
-static inline void processpmkidfile(char *pmkidname, int fd_cap)
+static void processpmkidfile(char *pmkidname, int fd_cap)
 {
 static int len;
 static int aktread = 1;
@@ -663,7 +663,7 @@ fclose(fhpmkid);
 return;
 }
 /*===========================================================================*/
-static inline void processhccapxfile(char *hccapxname, int fd_cap)
+static void processhccapxfile(char *hccapxname, int fd_cap)
 {
 static struct stat statinfo;
 static hccapx_t *hcxptr;
@@ -856,7 +856,7 @@ fclose(fhhcx);
 return;
 }
 /*===========================================================================*/
-static inline void processhccapfile(char *hccapname, int fd_cap)
+static void processhccapfile(char *hccapname, int fd_cap)
 {
 static struct stat statinfo;
 static hccap_t *hcptr;
@@ -1052,7 +1052,7 @@ fclose(fhhc);
 return;
 }
 /*===========================================================================*/
-static inline void processjohnfile(char *johnname, int fd_cap)
+static void processjohnfile(char *johnname, int fd_cap)
 {
 static int len;
 static int i;
@@ -1312,14 +1312,14 @@ return;
 }
 /*===========================================================================*/
 __attribute__ ((noreturn))
-static inline void version(char *eigenname)
+static void version(char *eigenname)
 {
 printf("%s %s (C) %s ZeroBeat\n", eigenname, VERSION, VERSION_JAHR);
 exit(EXIT_SUCCESS);
 }
 /*---------------------------------------------------------------------------*/
 __attribute__ ((noreturn))
-static inline void usage(char *eigenname)
+static void usage(char *eigenname)
 {
 printf("%s %s (C) %s ZeroBeat\n"
 	"usage:\n"
@@ -1343,7 +1343,7 @@ exit(EXIT_SUCCESS);
 }
 /*---------------------------------------------------------------------------*/
 __attribute__ ((noreturn))
-static inline void usageerror(char *eigenname)
+static void usageerror(char *eigenname)
 {
 printf("%s %s (C) %s by ZeroBeat\n"
 	"usage: %s -h for help\n", eigenname, VERSION, VERSION_JAHR, eigenname);

--- a/hcxpsktool.c
+++ b/hcxpsktool.c
@@ -1750,7 +1750,7 @@ return;
 }
 /*===========================================================================*/
 /*===========================================================================*/
-static inline size_t chop(char *buffer, size_t len)
+static size_t chop(char *buffer, size_t len)
 {
 static char *ptr;
 
@@ -1772,7 +1772,7 @@ while(len)
 return len;
 }
 /*---------------------------------------------------------------------------*/
-static inline int fgetline(FILE *inputstream, size_t size, char *buffer)
+static int fgetline(FILE *inputstream, size_t size, char *buffer)
 {
 static size_t len;
 static char *buffptr;
@@ -1787,7 +1787,7 @@ len = chop(buffptr, len);
 return len;
 }
 /*===========================================================================*/
-static inline void readpmkidfile(char *pmkidname)
+static void readpmkidfile(char *pmkidname)
 {
 static int len;
 static int aktread = 1;
@@ -1848,7 +1848,7 @@ fclose(fh_file);
 return;
 }
 /*===========================================================================*/
-static inline int getwpapskfmt(int lenlinein, char *linein)
+static int getwpapskfmt(int lenlinein, char *linein)
 {
 static int p;
 static const char *johnformat = "$WPAPSK$";
@@ -1863,7 +1863,7 @@ static const char *johnformat = "$WPAPSK$";
 return 0;
 }
 /*===========================================================================*/
-static inline void readjohnfile(char *johnname)
+static void readjohnfile(char *johnname)
 {
 static int len;
 static int aktread = 1;
@@ -1942,7 +1942,7 @@ fclose(fh_file);
 return;
 }
 /*===========================================================================*/
-static inline void readhccapxfile(char *hccapxname)
+static void readhccapxfile(char *hccapxname)
 {
 static struct stat statinfo;
 static hccapx_t *hcxptr;
@@ -1997,7 +1997,7 @@ fclose(fhhcx);
 return;
 }
 /*===========================================================================*/
-static inline void readcommandline(char *macapname, char *essidname)
+static void readcommandline(char *macapname, char *essidname)
 {
 static int essidlen = 0;
 static int essidlenuh = 0;
@@ -2038,14 +2038,14 @@ return;
 }
 /*===========================================================================*/
 __attribute__ ((noreturn))
-static inline void version(char *eigenname)
+static void version(char *eigenname)
 {
 printf("%s %s (C) %s ZeroBeat\n", eigenname, VERSION, VERSION_JAHR);
 exit(EXIT_SUCCESS);
 }
 /*---------------------------------------------------------------------------*/
 __attribute__ ((noreturn))
-static inline void usage(char *eigenname)
+static void usage(char *eigenname)
 {
 printf("%s %s (C) %s ZeroBeat\n"
 	"usage:\n"
@@ -2084,7 +2084,7 @@ exit(EXIT_SUCCESS);
 }
 /*---------------------------------------------------------------------------*/
 __attribute__ ((noreturn))
-static inline void usageerror(char *eigenname)
+static void usageerror(char *eigenname)
 {
 printf("%s %s (C) %s by ZeroBeat\n"
 	"usage: %s -h for help\n", eigenname, VERSION, VERSION_JAHR, eigenname);

--- a/hcxwltool.c
+++ b/hcxwltool.c
@@ -526,7 +526,7 @@ if(len >= 6)
 return len;
 }
 /*===========================================================================*/
-static inline size_t chop(char *buffer, size_t len)
+static size_t chop(char *buffer, size_t len)
 {
 static char *ptr;
 
@@ -548,7 +548,7 @@ while(len)
 return len;
 }
 /*---------------------------------------------------------------------------*/
-static inline int fgetline(FILE *fh_in, size_t size, char *buffer)
+static int fgetline(FILE *fh_in, size_t size, char *buffer)
 {
 static size_t len;
 static char *buffptr;
@@ -563,7 +563,7 @@ len = chop(buffptr, len);
 return len;
 }
 /*===========================================================================*/
-static inline void processwordlist(char *wordlistinname, FILE *fh_out)
+static void processwordlist(char *wordlistinname, FILE *fh_out)
 {
 static int len;
 static FILE *fh_in;
@@ -611,14 +611,14 @@ return;
 }
 /*===========================================================================*/
 __attribute__ ((noreturn))
-static inline void version(char *eigenname)
+static void version(char *eigenname)
 {
 printf("%s %s (C) %s ZeroBeat\n", eigenname, VERSION, VERSION_JAHR);
 exit(EXIT_SUCCESS);
 }
 /*---------------------------------------------------------------------------*/
 __attribute__ ((noreturn))
-static inline void usage(char *eigenname)
+static void usage(char *eigenname)
 {
 printf("%s %s (C) %s ZeroBeat\n"
 	"usage:\n"
@@ -650,7 +650,7 @@ exit(EXIT_SUCCESS);
 }
 /*---------------------------------------------------------------------------*/
 __attribute__ ((noreturn))
-static inline void usageerror(char *eigenname)
+static void usageerror(char *eigenname)
 {
 printf("%s %s (C) %s by ZeroBeat\n"
 	"usage: %s -h for help\n", eigenname, VERSION, VERSION_JAHR, eigenname);


### PR DESCRIPTION
This breaks compilation with c89. It's also fairly useless as compilers
can make better decisions.