### PR TITLE
unbreak build on OpenBSD due to undeclared identifier PATH_MAX

### DIFF
--- a/hcxpcaptool.c
+++ b/hcxpcaptool.c
@@ -18,6 +18,9 @@
 #include <openssl/hmac.h>
 #include <openssl/cmac.h>
 #if defined (__APPLE__) || defined(__OpenBSD__)
+#if defined(__OpenBSD__)
+#define PATH_MAX 1024	/* as defined in sys/syslimits.h */
+#endif
 #include <libgen.h>
 #include <sys/socket.h>
 #else


### PR DESCRIPTION
in version 5.3.0, there was a PATH_MAX defined for APPLE and OpenBSD
    set to 255.
    Re-add PATH_MAX define for OpenBSD, as it is defined in sys/syslimits.h
    set to 1024