### PR TITLE
wlancap2wpasec: remove trailing "32" in key cookie to fix key uploads

### DIFF
--- a/wlancap2wpasec.c
+++ b/wlancap2wpasec.c
@@ -162,7 +162,7 @@ while ((auswahl = getopt(argc, argv, "k:u:t:e:Rhv")) != -1)
 		case 'k':
 		if((strlen(optarg) == 32) && (optarg[strspn(optarg, "0123456789abcdefABCDEF")] == 0))
 			{
-			snprintf(keyheader, sizeof(keyheader), "key=%s32", optarg);
+			snprintf(keyheader, sizeof(keyheader), "key=%s", optarg);
 			printf("\x1B[32muser key set\x1B[0m\n");
 			}
 		else


### PR DESCRIPTION
This appears to be intended as `%32s` to limit the string length, but there are already checks above that ensure exact length is 32. Without this fix, all the `key` cookies end up like `<key>32`, making the uploaded data not show up for the requested key.