### PR TITLE
use pkg-config & fix build on macos with macports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@ OPENSSL_LIBS=$(shell pkg-config --libs openssl)
 OPENSSL_CFLAGS=$(shell pkg-config --cflags openssl)
 CURL_LIBS=$(shell pkg-config --libs libcurl)
 CURL_CFLAGS=$(shell pkg-config --cflags libcurl)
+Z_LIBS=$(shell pkg-config --libs zlib)
+Z_CFLAGS=$(shell pkg-config --cflags zlib)
 
 TOOLS=
 TOOLS+=hcxpcapngtool
-hcxpcapngtool_libs=-lz $(OPENSSL_LIBS)
-hcxpcapngtool_cflags=$(OPENSSL_CFLAGS)
+hcxpcapngtool_libs=$(OPENSSL_LIBS) $(Z_LIBS)
+hcxpcapngtool_cflags=$(OPENSSL_CFLAGS) $(Z_CFLAGS)
 TOOLS+=hcxhashtool
 hcxhashtool_libs=$(OPENSSL_LIBS) $(CURL_LIBS)
 hcxhashtool_cflags=$(OPENSSL_CFLAGS) $(CURL_CFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -27,29 +27,35 @@ ifeq ($(HOSTOS), Linux)
 INSTFLAGS += -D
 endif
 
-ifeq ($(HOSTOS), Darwin)
-CFLAGS += -L/usr/local/opt/openssl/lib -I/usr/local/opt/openssl/include
-endif
+OPENSSL_LIBS=$(shell pkg-config --libs openssl)
+OPENSSL_CFLAGS=$(shell pkg-config --cflags openssl)
 
 TOOLS=
 TOOLS+=hcxpcapngtool
-hcxpcapngtool_libs=-lz -lcrypto -lssl
+hcxpcapngtool_libs=-lz $(OPENSSL_LIBS)
+hcxpcapngtool_cflags=$(OPENSSL_CFLAGS)
 TOOLS+=hcxhashtool
-hcxhashtool_libs=-lcrypto -lssl -lcurl
+hcxhashtool_libs=-lcurl $(OPENSSL_LIBS)
+hcxhashtool_cflags=$(OPENSSL_CFLAGS)
 TOOLS+=hcxpsktool
-hcxpsktool_libs=-lcrypto -lssl
+hcxpsktool_libs=$(OPENSSL_LIBS)
+hcxpsktool_cflags=$(OPENSSL_CFLAGS)
 TOOLS+=hcxeiutool
 TOOLS+=hcxwltool
 TOOLS+=hcxhash2cap
 TOOLS+=wlancap2wpasec
-wlancap2wpasec_libs=-lcrypto -lssl -lcurl
+wlancap2wpasec_libs=-lcurl $(OPENSSL_LIBS)
+wlancap2wpasec_cflags=$(OPENSSL_CFLAGS)
 TOOLS+=whoismac
-whoismac_libs=-lcrypto -lssl -lcurl
+whoismac_libs=-lcurl $(OPENSSL_LIBS)
+whoismac_cflags=$(OPENSSL_CFLAGS)
 
 TOOLS+=hcxpmkidtool
 TOOLS+=hcxhashcattool
-hcxhashcattool_libs=-lcrypto -lssl -lpthread
-hcxpmkidtool_libs=-lcrypto -lssl -lpthread
+hcxhashcattool_libs=-lpthread $(OPENSSL_LIBS)
+hcxhashcattool_cflags=$(OPENSSL_CFLAGS)
+hcxpmkidtool_libs=-lpthread $(OPENSSL_LIBS)
+hcxpmkidtool_cflags=$(OPENSSL_CFLAGS)
 TOOLS+=hcxmactool
 TOOLS+=hcxessidtool
 
@@ -66,9 +72,10 @@ build: $(TOOLS)
 define tool-build
 $(1)_src ?= $(1).c
 $(1)_libs ?=
+$(1)_cflags ?=
 
 $(1): $$($(1)_src) | .deps
-	$$(CC) $$(CFLAGS) $$(CPPFLAGS) -MMD -MF .deps/$$@.d -o $$@ $$($(1)_src) $$($(1)_libs) $$(LDFLAGS) $$(DEFS)
+	$$(CC) $$(CFLAGS) $$($(1)_cflags) $$(CPPFLAGS) -MMD -MF .deps/$$@.d -o $$@ $$($(1)_src) $$($(1)_libs) $$(LDFLAGS) $$(DEFS)
 
 .deps/$(1).d: $(1)
 

--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,16 @@ endif
 
 OPENSSL_LIBS=$(shell pkg-config --libs openssl)
 OPENSSL_CFLAGS=$(shell pkg-config --cflags openssl)
+CURL_LIBS=$(shell pkg-config --libs libcurl)
+CURL_CFLAGS=$(shell pkg-config --cflags libcurl)
 
 TOOLS=
 TOOLS+=hcxpcapngtool
 hcxpcapngtool_libs=-lz $(OPENSSL_LIBS)
 hcxpcapngtool_cflags=$(OPENSSL_CFLAGS)
 TOOLS+=hcxhashtool
-hcxhashtool_libs=-lcurl $(OPENSSL_LIBS)
-hcxhashtool_cflags=$(OPENSSL_CFLAGS)
+hcxhashtool_libs=$(OPENSSL_LIBS) $(CURL_LIBS)
+hcxhashtool_cflags=$(OPENSSL_CFLAGS) $(CURL_CFLAGS)
 TOOLS+=hcxpsktool
 hcxpsktool_libs=$(OPENSSL_LIBS)
 hcxpsktool_cflags=$(OPENSSL_CFLAGS)
@@ -44,11 +46,11 @@ TOOLS+=hcxeiutool
 TOOLS+=hcxwltool
 TOOLS+=hcxhash2cap
 TOOLS+=wlancap2wpasec
-wlancap2wpasec_libs=-lcurl $(OPENSSL_LIBS)
-wlancap2wpasec_cflags=$(OPENSSL_CFLAGS)
+wlancap2wpasec_libs=$(OPENSSL_LIBS) $(CURL_LIBS)
+wlancap2wpasec_cflags=$(OPENSSL_CFLAGS) $(CURL_CFLAGS)
 TOOLS+=whoismac
-whoismac_libs=-lcurl $(OPENSSL_LIBS)
-whoismac_cflags=$(OPENSSL_CFLAGS)
+whoismac_libs=$(OPENSSL_LIBS) $(CURL_LIBS)
+whoismac_cflags=$(OPENSSL_CFLAGS) $(CURL_CFLAGS)
 
 TOOLS+=hcxpmkidtool
 TOOLS+=hcxhashcattool

--- a/hcxeiutool.c
+++ b/hcxeiutool.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include <libgen.h>
 #include <ctype.h>
 #include <getopt.h>
 #include <stdarg.h>


### PR DESCRIPTION
Fixes one build issue on macos 10.15, and also uses pkg-config to locate libraries (so that macports libraries are used).

The pkg-config usage should also improve behavior on linux systems.