### PR TITLE
fix typo in hcxpcapngtool contentinfo (IE_TAG)

### DIFF
--- a/hcxpcapngtool.c
+++ b/hcxpcapngtool.c
@@ -669,7 +669,7 @@ if(beaconcount > 0)
 		}
 	if((beaconchannel[0] &GHZ5) == GHZ5)
 		{
-		fprintf(stdout, "BEACON on 5/6 GHz channel (from IE-TAG)..: ");
+		fprintf(stdout, "BEACON on 5/6 GHz channel (from IE_TAG)..: ");
 		for(i = 15; i < CHANNEL_MAX; i++)
 			{
 			if(beaconchannel[i] != 0) fprintf(stdout, "%d ", i);


### PR DESCRIPTION
While studying `hcxpcapngtool` summaries I noticed a typo which I fixed:

```
$ hcxpcapngtool test.pcapng.gz -o test.22000
...
summary capture file
--------------------
...
BEACON on 2.4 GHz channel (from IE_TAG)..: 1 2 3 4 5 6 7 8 9 10 11 13
BEACON on 5/6 GHz channel (from IE-TAG)..: 36 100
...
```

'IE-TAG' --> 'IE_TAG'