### PR TITLE
fix typo in hcxhashtool status (entries)

### DIFF
--- a/hcxhashtool.c
+++ b/hcxhashtool.c
@@ -206,7 +206,7 @@ static void printstatus()
 static char *vendor;
 
 fprintf(stdout, "\nOUI information file..........: %s\n", usedoui);
-if(ouicount > 0)		fprintf(stdout, "OUI entires...................: %d\n", ouicount);
+if(ouicount > 0)		fprintf(stdout, "OUI entries...................: %d\n", ouicount);
 if(readcount > 0)		fprintf(stdout, "total lines read..............: %ld\n", readcount);
 if(flagvendorout == true)
 	{


### PR DESCRIPTION
While experimenting with `hcxhashtool` I noticed a typo which I fixed:

```
$ hcxhashtool -i hash.22000              

OUI information file..........: /home/gemesa/.hcxtools/oui.txt
OUI entires...................: 33542
total lines read..............: 1
valid hash lines..............: 1
EAPOL hash lines..............: 1
```

'entires' --> 'entries'