### PR TITLE
remove deprecated hcxpmkidtool from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ hcxeiutool
 hcxhash2cap
 hcxhashtool
 hcxpcapngtool
-hcxpmkidtool
 hcxpmktool
 hcxpsktool
 hcxwltool


### PR DESCRIPTION
Some deprecated tools have been removed in https://github.com/ZerBea/hcxtools/commit/60b1801054cdddda06cfc1fa31e5a56e0a46f8d1 but `hcxpmkidtool` was still in the `.gitignore` so I removed it also.