### PR TITLE
extend 'make install' instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,20 @@ git clone https://github.com/ZerBea/hcxtools.git
 cd hcxtools
 ```
 
-Compile
+Compile & install
 --------------
 ```
 make
+```
+
+install to `/usr/bin`:
+```
 make install (as super user)
+```
+
+or install to `/usr/local/bin`:
+```
+make install PREFIX=/usr/local (as super user)
 ```
 
 Or install via packet manager of your distribution


### PR DESCRIPTION
`make install` installs by default the executables under `/usr/bin` which is unfortunate because the distribution-managed packages are stored there so this can cause conflicts. Fortunately the `Makefile` is prepared for this so we can install to other locations instead, this is just not reflected in the readme so I updated it.

```
$ sudo make install PREFIX=/usr/local                                         
install -D -m 0755 hcxpcapngtool /usr/local/bin/hcxpcapngtool
install -D -m 0755 hcxhashtool /usr/local/bin/hcxhashtool
install -D -m 0755 hcxpsktool /usr/local/bin/hcxpsktool
install -D -m 0755 hcxpmktool /usr/local/bin/hcxpmktool
install -D -m 0755 hcxeiutool /usr/local/bin/hcxeiutool
install -D -m 0755 hcxwltool /usr/local/bin/hcxwltool
install -D -m 0755 hcxhash2cap /usr/local/bin/hcxhash2cap
install -D -m 0755 wlancap2wpasec /usr/local/bin/wlancap2wpasec
install -D -m 0755 whoismac /usr/local/bin/whoismac
```