### PR TITLE
fix typo in makefile (DCFLAGS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ HOSTOS		:= $(shell uname -s)
 
 CC		?= gcc
 CFLAGS		?= -O3 -Wall -Wextra
-DCFLAGS		+= -std=gnu99
+CFLAGS		+= -std=gnu99
 DEFS		= -DVERSION_TAG=\"$(VERSION_TAG)\" -DVERSION_YEAR=\"$(VERSION_YEAR)\"
 DEFS		+= -DWANTZLIB
 


### PR DESCRIPTION
While reviewing `Makefile` I noticed a typo which I fixed. Previously this resulted in `-std=gnu99` not being appended to `CFLAGS`.