### PR TITLE
add some cleanups in hcxpcapngtool (f to channel conversion)

### DIFF
--- a/hcxpcapngtool.c
+++ b/hcxpcapngtool.c
@@ -4461,7 +4461,7 @@ if((rth->it_present & IEEE80211_RADIOTAP_CHANNEL) == IEEE80211_RADIOTAP_CHANNEL)
 		interfacechannel = (frequency -2407)/5;
 		band24count++;
 		}
-	else if((frequency == 2484) && (frequency <= 2487))
+	else if(frequency == 2484)
 		{
 		interfacechannel = (frequency -2412)/5;
 		band24count++;

--- a/hcxpcapngtool.c
+++ b/hcxpcapngtool.c
@@ -4463,7 +4463,7 @@ if((rth->it_present & IEEE80211_RADIOTAP_CHANNEL) == IEEE80211_RADIOTAP_CHANNEL)
 		}
 	else if(frequency == 2484)
 		{
-		interfacechannel = (frequency -2412)/5;
+		interfacechannel = 14;
 		band24count++;
 		}
 	else if((frequency >=  5180) && (frequency <= 5905))


### PR DESCRIPTION
While reviewing `hcxpcapngtool.c` I noticed the followings:

here the 2nd expression is redundant:
```
if((frequency == 2484) && (frequency <= 2487))
```


when converting `frequency == 2484` to `interfacechannel = 14` this expression can be simplified:
```
interfacechannel = (frequency -2412)/5;
```
to
```
interfacechannel = 14;
```
I mean (2484 -2412)/5 = 14.4 so technically this will be also 14 after casting to `int` but hardcoding 14 is just more readable. Also it is hardcoded in `hcxlabtool.c` for example:
```
static u16 frequency_to_channel(u32 frequency)
{
if(frequency == 2484) return 14;
else if(frequency < 2484) return (frequency - 2407) / 5;
...
```