### PR TITLE
remove deprecated hcxpioff from manpage

### DIFF
--- a/man/hcxtools.1
+++ b/man/hcxtools.1
@@ -19,7 +19,7 @@ Small set of tools convert packets from WiFi captures to detect weak points with
 .SH OPTIONS
 help menu (-h or --help) of each tool will list all available options
 .SH RELATED TOOLS
-hcxdumptool, hcxpioff, wlangenpmk, wlangenpmkocl
+hcxdumptool, wlangenpmk, wlangenpmkocl
 .SH BUGS
 no known bugs.
 .SH AUTHOR


### PR DESCRIPTION
`hcxpioff.c` has been removed in https://github.com/ZerBea/hcxdumptool/commit/311e09325d70a0774d25f687b285c3af26ca7519, lets update `manpage`